### PR TITLE
Add Filter for affiliates

### DIFF
--- a/affiliatewp-leaderboard.php
+++ b/affiliatewp-leaderboard.php
@@ -215,7 +215,7 @@ final class AffiliateWP_Leaderboard {
 		$show_visits = isset( $args['visits'] ) && ( 'yes' == $args['visits'] || 'on' == $args['visits'] ) ? true : false;
 
 		// get affiliates
-		$affiliates = affiliate_wp()->affiliates->get_affiliates( $defaults );
+		$affiliates = apply_filters( 'affiliatewp_leaderboard_get_affiliates', affiliate_wp()->affiliates->get_affiliates( $defaults ), $args );
 
 		ob_start();
 


### PR DESCRIPTION
Needing a fairly heavily customized leaderboard - and since we have no meta_query support (https://github.com/AffiliateWP/AffiliateWP/issues/2021) and no filters applied at the DB API level - a filter here would be super helpful!

A future PR (if it would be acceptable) might include an overrideable template for the output here. Currently, we'll have to rely on a bit of hackery on the affwp_show_leaderboard filter.

Cheers!